### PR TITLE
Fix the CI pipeline and drop support for older Rails versions

### DIFF
--- a/Appraisals
+++ b/Appraisals
@@ -1,21 +1,16 @@
 # frozen_string_literal: true
 
-appraise 'activejob-4.2.x' do
-  gem 'rails', '~> 4.2.11'
-end
-
-appraise 'activejob-5.2.x' do
-  gem 'rails', '~> 5.2.4'
-end
-
 appraise 'activejob-6.0.x' do
   gem 'rails', '~> 6.0.3'
+  gem 'concurrent-ruby', '1.3.4'
 end
 
 appraise 'activejob-6.1.x' do
   gem 'rails', '~> 6.1.0'
+  gem 'concurrent-ruby', '1.3.4'
 end
 
 appraise 'activejob-7.0.x' do
   gem 'rails', '~> 7.0.0'
+  gem 'concurrent-ruby', '1.3.4'
 end

--- a/advanced-sneakers-activejob.gemspec
+++ b/advanced-sneakers-activejob.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'bunny-publisher', '~> 0.2.0'
   spec.add_dependency 'sneakers', '~> 2.7'
 
-  spec.add_development_dependency 'appraisal', '~> 2.3.0'
+  spec.add_development_dependency 'appraisal', '~> 2.5.0'
   spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'pry-byebug'
   spec.add_development_dependency 'rabbitmq_http_api_client', '~> 1.13'

--- a/gemfiles/activejob_6.0.x.gemfile
+++ b/gemfiles/activejob_6.0.x.gemfile
@@ -3,5 +3,6 @@
 source "https://rubygems.org"
 
 gem "rails", "~> 6.0.3"
+gem "concurrent-ruby", "1.3.4"
 
 gemspec path: "../"

--- a/gemfiles/activejob_6.1.x.gemfile
+++ b/gemfiles/activejob_6.1.x.gemfile
@@ -3,5 +3,6 @@
 source "https://rubygems.org"
 
 gem "rails", "~> 6.1.0"
+gem "concurrent-ruby", "1.3.4"
 
 gemspec path: "../"

--- a/gemfiles/activejob_7.0.x.gemfile
+++ b/gemfiles/activejob_7.0.x.gemfile
@@ -3,5 +3,6 @@
 source "https://rubygems.org"
 
 gem "rails", "~> 7.0.0"
+gem "concurrent-ruby", "1.3.4"
 
 gemspec path: "../"


### PR DESCRIPTION
- Upgrade Appraisal to fix issue https://github.com/thoughtbot/appraisal/issues/218
- Pin concurrent-ruby to 1.3.4 to fix issue https://github.com/rails/rails/issues/54260
  - This issue was fixed in Rails 7.1
- Drop support for Rails 4.2 and 5.2 due to broken dependencies