### PR TITLE
Clean up CI build matrix

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,18 +25,10 @@ jobs:
           - '2.7'
           - '3.0'
         gemfile:
-          - gemfiles/activejob_4.2.x.gemfile
-          - gemfiles/activejob_5.2.x.gemfile
           - gemfiles/activejob_6.0.x.gemfile
           - gemfiles/activejob_6.1.x.gemfile
           - gemfiles/activejob_7.0.x.gemfile
         exclude:
-          - ruby: '2.7'
-            gemfile: gemfiles/activejob_4.2.x.gemfile
-          - ruby: '3.0'
-            gemfile: gemfiles/activejob_4.2.x.gemfile
-          - ruby: '3.0'
-            gemfile: gemfiles/activejob_5.2.x.gemfile
           - ruby: '2.5'
             gemfile: gemfiles/activejob_7.0.x.gemfile
           - ruby: '2.6'


### PR DESCRIPTION
Cleans up the CI build matrix to stop runs for unsupported versions.