### PR TITLE
Bump up the version requirement for acitvejob in gemspec

### DIFF
--- a/advanced-sneakers-activejob.gemspec
+++ b/advanced-sneakers-activejob.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |spec|
 
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'activejob', '>= 4.2'
+  spec.add_dependency 'activejob', '>= 6.0'
   spec.add_dependency 'bunny-publisher', '~> 0.2.0'
   spec.add_dependency 'sneakers', '~> 2.7'
 


### PR DESCRIPTION
Just bumps the version requirement for Rails / ActiveJob