### PR TITLE
Migrate to kicks instead of sneakers as a dependency

### DIFF
--- a/advanced-sneakers-activejob.gemspec
+++ b/advanced-sneakers-activejob.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'activejob', '>= 6.0'
   spec.add_dependency 'bunny-publisher', '~> 0.2.0'
-  spec.add_dependency 'sneakers', '~> 2.7'
+  spec.add_dependency 'kicks', '~> 3.0'
 
   spec.add_development_dependency 'appraisal', '~> 2.5.0'
   spec.add_development_dependency 'bundler'


### PR DESCRIPTION
Moves from sneakers gem to kicks gem. Its a drop-in replacement so no other change should be required.