### PR TITLE
[BEP-9889] Auto-bind ActiveJob worker queues to delay.delivery.x at subscribe

### DIFF
--- a/lib/advanced_sneakers_activejob.rb
+++ b/lib/advanced_sneakers_activejob.rb
@@ -18,6 +18,7 @@ require 'advanced_sneakers_activejob/errors'
 require 'advanced_sneakers_activejob/publisher'
 require 'advanced_sneakers_activejob/delayed_publisher'
 require 'advanced_sneakers_activejob/leveled_delayed_publisher'
+require 'advanced_sneakers_activejob/sneakers_queue_patch'
 require 'advanced_sneakers_activejob/active_job_patch'
 require 'advanced_sneakers_activejob/railtie' if defined?(::Rails::Railtie)
 require 'active_job/queue_adapters/advanced_sneakers_adapter'

--- a/lib/advanced_sneakers_activejob/sneakers_queue_patch.rb
+++ b/lib/advanced_sneakers_activejob/sneakers_queue_patch.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+module AdvancedSneakersActiveJob
+  # Prepended to Sneakers::Queue to restore the "reachable for immediate jobs
+  # implies reachable for delayed jobs" invariant of the legacy delayed path.
+  #
+  # Matured messages leave the leveled delay topology via a broker-internal
+  # dead-letter republish to LeveledDelayedPublisher::DELIVERY_EXCHANGE, so an
+  # unbound destination queue drops them silently (no mandatory flag or
+  # publisher callback can catch it). Binding at subscribe time covers every
+  # consumer of the ActiveJob exchange, including host-defined worker classes
+  # that bypass AdvancedSneakersActiveJob.define_consumer, and is independent
+  # of the worker's handler.
+  #
+  # The bind is deliberately NOT gated on config.delayed_delivery: it is a
+  # per-publish (potentially callable) setting, so its boot-time value proves
+  # nothing. An extra durable binding is inert while the leveled path is
+  # unused and makes flag flips safe in both directions.
+  module SneakersQueuePatch
+    class << self
+      # Tracks bound queue names to warn about topic cross-matches:
+      # "#.b" also matches deliveries destined for queue "a.b".
+      def cross_matching_names(name)
+        @mutex ||= Mutex.new
+        @mutex.synchronize do
+          @known_names ||= Set.new
+          matches = @known_names.select { |other| other.end_with?(".#{name}") || name.end_with?(".#{other}") }.to_a
+          @known_names << name
+          matches
+        end
+      end
+    end
+
+    def subscribe(worker)
+      super.tap { bind_to_delayed_delivery_exchange }
+    end
+
+    private
+
+    def bind_to_delayed_delivery_exchange
+      return unless opts[:exchange] == AdvancedSneakersActiveJob.config.sneakers[:exchange]
+
+      delivery_exchange = LeveledDelayedPublisher::DELIVERY_EXCHANGE
+
+      # Idempotent declare first: binding to a missing exchange 404s and
+      # closes the consumer channel on hosts that never declared the topology.
+      channel.topic(delivery_exchange, durable: true)
+      channel.queue_bind(name, delivery_exchange, routing_key: "#.#{name}")
+
+      warn_on_cross_matching_names(delivery_exchange)
+    rescue StandardError => e
+      # Fail open: a consumer without the delay binding beats a crash-looping
+      # fleet. Delayed jobs maturing for this queue are dropped until the
+      # binding exists.
+      log_bind_failure(delivery_exchange, e)
+    end
+
+    def log_bind_failure(delivery_exchange, error)
+      (Sneakers.logger || Logger.new($stderr)).error(
+        "Failed to bind queue [#{name}] to exchange [#{delivery_exchange}]: #{error.class}: #{error.message}"
+      )
+    end
+
+    def warn_on_cross_matching_names(delivery_exchange)
+      SneakersQueuePatch.cross_matching_names(name).each do |other|
+        Sneakers.logger&.warn "Queue [#{name}] binding [#.#{name}] on [#{delivery_exchange}] cross-matches queue [#{other}]"
+      end
+    end
+  end
+end
+
+Sneakers::Queue.prepend(AdvancedSneakersActiveJob::SneakersQueuePatch)

--- a/lib/advanced_sneakers_activejob/sneakers_queue_patch.rb
+++ b/lib/advanced_sneakers_activejob/sneakers_queue_patch.rb
@@ -21,15 +21,17 @@ module AdvancedSneakersActiveJob
       # Tracks bound queue names to warn about topic cross-matches:
       # "#.b" also matches deliveries destined for queue "a.b".
       def cross_matching_names(name)
-        @mutex ||= Mutex.new
         @mutex.synchronize do
-          @known_names ||= Set.new
           matches = @known_names.select { |other| other.end_with?(".#{name}") || name.end_with?(".#{other}") }.to_a
           @known_names << name
           matches
         end
       end
     end
+
+    # Eager init: subscribers run concurrently, lazy ||= would race.
+    @mutex = Mutex.new
+    @known_names = Set.new
 
     def subscribe(worker)
       super.tap { bind_to_delayed_delivery_exchange }
@@ -42,17 +44,32 @@ module AdvancedSneakersActiveJob
 
       delivery_exchange = LeveledDelayedPublisher::DELIVERY_EXCHANGE
 
-      # Idempotent declare first: binding to a missing exchange 404s and
-      # closes the consumer channel on hosts that never declared the topology.
-      channel.topic(delivery_exchange, durable: true)
-      channel.queue_bind(name, delivery_exchange, routing_key: "#.#{name}")
-
+      declare_and_bind(delivery_exchange)
       warn_on_cross_matching_names(delivery_exchange)
     rescue StandardError => e
       # Fail open: a consumer without the delay binding beats a crash-looping
       # fleet. Delayed jobs maturing for this queue are dropped until the
       # binding exists.
       log_bind_failure(delivery_exchange, e)
+    end
+
+    # Dedicated short-lived channel: broker-side declare/bind failures
+    # (403 access_refused, 406 precondition_failed) close the channel that
+    # issued them, which must never be the consumer's.
+    def declare_and_bind(delivery_exchange)
+      bind_channel = channel.connection.create_channel
+      # Idempotent declare first: binding to a missing exchange 404s on
+      # hosts that never declared the topology.
+      bind_channel.topic(delivery_exchange, durable: true)
+
+      # Matured messages carry routing key "<bits>.<original key>", so mirror
+      # every immediate-path binding key (kicks binds routing_key || name),
+      # plus the queue name — the default for fresh delayed publishes.
+      [*(opts[:routing_key] || name), name].uniq.each do |key|
+        bind_channel.queue_bind(name, delivery_exchange, routing_key: "#.#{key}")
+      end
+    ensure
+      bind_channel.close if bind_channel&.open?
     end
 
     def log_bind_failure(delivery_exchange, error)

--- a/spec/sneakers/queue_spec.rb
+++ b/spec/sneakers/queue_spec.rb
@@ -30,6 +30,16 @@ describe 'Sneakers::Queue patch' do
       end
     end
 
+    context 'with a custom routing key' do
+      let(:opts) { AdvancedSneakersActiveJob.config.sneakers.merge(connection: connection, routing_key: 'custom_key') }
+
+      it 'binds delay.delivery.x for the routing key and the queue name' do
+        queue.subscribe(worker)
+
+        expect(routing_keys(queue: 'custom', exchange: 'delay.delivery.x')).to contain_exactly('#.custom', '#.custom_key')
+      end
+    end
+
     context 'with a non-ActiveJob exchange' do
       let(:opts) { AdvancedSneakersActiveJob.config.sneakers.merge(connection: connection, exchange: 'sneakers') }
 
@@ -55,7 +65,9 @@ describe 'Sneakers::Queue patch' do
       end
 
       before do
-        allow_any_instance_of(Bunny::Channel).to receive(:topic).and_raise('the broker said no')
+        # Real broker refusal: mismatched exchange type makes the declare fail
+        # with 406 PRECONDITION_FAILED, which closes the declaring channel.
+        connection.create_channel.fanout('delay.delivery.x', durable: true)
       end
 
       it 'logs an error and consumes anyway' do
@@ -63,7 +75,8 @@ describe 'Sneakers::Queue patch' do
         allow(worker).to receive(:do_work) { |_, _, msg, _| messages.push(msg) }
 
         expect { queue.subscribe(worker) }.not_to raise_error
-        expect(log.string).to include('Failed to bind queue [custom] to exchange [delay.delivery.x]: RuntimeError: the broker said no')
+        expect(log.string).to include('Failed to bind queue [custom] to exchange [delay.delivery.x]')
+        expect(log.string).to include('PRECONDITION_FAILED')
 
         connection.create_channel.direct('activejob', durable: true).publish('payload', routing_key: 'custom')
 

--- a/spec/sneakers/queue_spec.rb
+++ b/spec/sneakers/queue_spec.rb
@@ -80,7 +80,7 @@ describe 'Sneakers::Queue patch' do
 
         connection.create_channel.direct('activejob', durable: true).publish('payload', routing_key: 'custom')
 
-        expect(messages.pop(timeout: 5)).to eq('payload')
+        expect(Timeout.timeout(5) { messages.pop }).to eq('payload')
       end
     end
   end

--- a/spec/sneakers/queue_spec.rb
+++ b/spec/sneakers/queue_spec.rb
@@ -1,0 +1,83 @@
+# frozen_string_literal: true
+
+describe 'Sneakers::Queue patch' do
+  describe '#subscribe', :rabbitmq do
+    let(:connection) { Bunny.new(ENV.fetch('RABBITMQ_URL')).start }
+    let(:opts) { AdvancedSneakersActiveJob.config.sneakers.merge(connection: connection) }
+    let(:worker) { double('worker', opts: { handler: AdvancedSneakersActiveJob::Handler }) }
+    let(:queue) { Sneakers::Queue.new('custom', opts) }
+
+    after { connection.close }
+
+    def routing_keys(queue:, exchange:)
+      rabbitmq_bindings(queue: queue, exchange: exchange).map(&:routing_key)
+    end
+
+    it 'binds the queue to both the ActiveJob exchange and delay.delivery.x' do
+      queue.subscribe(worker)
+
+      expect(routing_keys(queue: 'custom', exchange: 'activejob')).to eq(['custom'])
+      expect(routing_keys(queue: 'custom', exchange: 'delay.delivery.x')).to eq(['#.custom'])
+    end
+
+    context 'with a custom handler' do
+      let(:worker) { double('worker', opts: { handler: Sneakers::Handlers::Oneshot }) }
+
+      it 'still binds to delay.delivery.x' do
+        queue.subscribe(worker)
+
+        expect(routing_keys(queue: 'custom', exchange: 'delay.delivery.x')).to eq(['#.custom'])
+      end
+    end
+
+    context 'with a non-ActiveJob exchange' do
+      let(:opts) { AdvancedSneakersActiveJob.config.sneakers.merge(connection: connection, exchange: 'sneakers') }
+
+      it 'does not bind to delay.delivery.x' do
+        connection.create_channel.topic('delay.delivery.x', durable: true) # so the bindings query does not 404
+
+        queue.subscribe(worker)
+
+        expect(routing_keys(queue: 'custom', exchange: 'sneakers')).to eq(['custom'])
+        expect(routing_keys(queue: 'custom', exchange: 'delay.delivery.x')).to eq([])
+      end
+    end
+
+    context 'when the bind fails' do
+      let(:log) { StringIO.new }
+
+      around do |example|
+        original_logger = Sneakers.logger
+        Sneakers.logger = Logger.new(log)
+        example.run
+      ensure
+        Sneakers.logger = original_logger
+      end
+
+      before do
+        allow_any_instance_of(Bunny::Channel).to receive(:topic).and_raise('the broker said no')
+      end
+
+      it 'logs an error and consumes anyway' do
+        messages = Queue.new
+        allow(worker).to receive(:do_work) { |_, _, msg, _| messages.push(msg) }
+
+        expect { queue.subscribe(worker) }.not_to raise_error
+        expect(log.string).to include('Failed to bind queue [custom] to exchange [delay.delivery.x]: RuntimeError: the broker said no')
+
+        connection.create_channel.direct('activejob', durable: true).publish('payload', routing_key: 'custom')
+
+        expect(messages.pop(timeout: 5)).to eq('payload')
+      end
+    end
+  end
+
+  describe AdvancedSneakersActiveJob::SneakersQueuePatch, '.cross_matching_names' do
+    it 'reports known queue names that dot-suffix the new name (and vice versa)' do
+      expect(described_class.cross_matching_names('crossmatch.a.b')).to eq([])
+      expect(described_class.cross_matching_names('b')).to eq(['crossmatch.a.b'])
+      expect(described_class.cross_matching_names('a.b')).to eq(['crossmatch.a.b', 'b'])
+      expect(described_class.cross_matching_names('unrelated')).to eq([])
+    end
+  end
+end


### PR DESCRIPTION
## What

Prepends `Sneakers::Queue#subscribe` so that every worker consuming from the configured ActiveJob exchange also idempotently declares the leveled delayed-delivery exchange `delay.delivery.x` (topic, durable) and binds its queue to it with routing key `#.<queue_name>`.

## Why

Under leveled delayed delivery, a matured message's final hop is a broker-internal dead-letter republish into `delay.delivery.x` — if the destination queue has no `#.<queue>` binding there, the message is **silently dropped** (no `mandatory` flag or publisher callback can catch it). This lost a production job on `accruals_compute_queue` ([BEP-9880](https://linear.app/branch/issue/BEP-9880)). This restores the "reachable for immediate ⟹ reachable for delayed" invariant inside the gem, the way the legacy per-delay-queue design had it for free.

Linear: [BEP-9889](https://linear.app/branch/issue/BEP-9889)

## Design constraints honored (see ticket "Hard constraints")

- Hooked at `Sneakers::Queue#subscribe` (prepend), **not** the gem `Handler` — hosts that override `handler:` (BranchServer uses `Sneakers::Handlers::Oneshot`) or define workers outside `define_consumer` are still covered.
- **Not** gated on `config.delayed_delivery` — that's a per-publish callable; the extra durable binding is inert when the leveled path is unused and makes flag flips safe both ways.
- `delay.delivery.x` is declared (topic, durable — byte-matching `LeveledDelayedPublisher::DELIVERY_EXCHANGE` / `declare_topology!`) before binding, so the bind can't 404 on hosts that never ran `declare_topology!`.
- Declare/bind failures are rescued and logged at error level (naming queue + exchange); the consumer still starts.
- Scoped to workers whose exchange == the gem's configured ActiveJob exchange; other Sneakers workers untouched.
- Relies only on `Sneakers::Queue#subscribe`'s stable surface (`@name`, `@opts`, `@channel`) — compatible with kicks 3.2.0 and the 3.3.0.pre fork.

## Stacking

First PR of the BEP-988x gem series; based on `main`. BEP-9891 (parking exchange/queue) stacks on this branch.

## Verification

- Full suite green under `BUNDLE_GEMFILE=gemfiles/activejob_7.1.x.gemfile bundle exec rspec` against a local RabbitMQ.
- New specs: queue bound to both `activejob` and `delay.delivery.x`; bind occurs with a custom `handler:`; non-ActiveJob workers (different exchange) untouched; bind failure logs an error and consumer still starts.
- An adversarial review pass against the ticket's hard constraints runs as part of this session; any resulting fixes will be pushed to this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)