### PR TITLE
[BEP-9890] Ensure destination binding just-in-time before delayed publish

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,7 +11,10 @@ jobs:
 
     services:
       rabbitmq:
-        image: rabbitmq:3.8-management-alpine
+        # Quorum queues gained x-message-ttl support in RabbitMQ 3.10; the
+        # leveled delayed topology (delay.level.* quorum queues with TTL)
+        # cannot be declared on older brokers. Match production (>= 3.10).
+        image: rabbitmq:3.13-management-alpine
         options: >-
           --health-cmd "rabbitmq-diagnostics -q listeners"
           --health-interval 10s

--- a/README.md
+++ b/README.md
@@ -72,6 +72,8 @@ Take into accout that **this process is asynchronous**. It means that in case of
 
 ## Leveled delayed delivery: parking unroutable messages
 
+**Requirements:** the leveled path declares the `delay.level.*` queues as quorum queues with per-level message TTL (`x-message-ttl`), which RabbitMQ supports on quorum queues only from **3.10** onwards. On older brokers `LeveledDelayedPublisher#declare_topology!` fails fast with `AdvancedSneakersActiveJob::BrokerVersionError` rather than a cryptic `PRECONDITION_FAILED`; run `config.delayed_delivery = :legacy` on brokers below 3.10.
+
 The leveled delayed topology terminates on the `delay.delivery.x` topic exchange. A message reaching it with no matching binding would be silently dropped — the final hop is a broker-internal dead-letter republish, so the `mandatory` flag cannot catch it. As a safety net, `LeveledDelayedPublisher#declare_topology!` also declares:
 
 - durable fanout exchange `delay.delivery.unrouted.x`

--- a/README.md
+++ b/README.md
@@ -70,6 +70,34 @@ Take into accout that **this process is asynchronous**. It means that in case of
 
 **Delayed messages are not handled!** If job is delayed `GuestsCleanupJob.set(wait: 1.week).perform_later(guest)` and there is no proper routing defined at the moment of job execution, it would be lost.
 
+## Leveled delayed delivery: parking unroutable messages
+
+The leveled delayed topology terminates on the `delay.delivery.x` topic exchange. A message reaching it with no matching binding would be silently dropped — the final hop is a broker-internal dead-letter republish, so the `mandatory` flag cannot catch it. As a safety net, `LeveledDelayedPublisher#declare_topology!` also declares:
+
+- durable fanout exchange `delay.delivery.unrouted.x`
+- durable quorum queue `delay.delivery.parking`, bound to that exchange
+
+To route unroutable messages into it, attach the alternate exchange to `delay.delivery.x` **via policy** as part of leveled-topology setup:
+
+```sh
+rabbitmqctl set_policy delay-delivery-ae '^delay\.delivery\.x$' \
+  '{"alternate-exchange":"delay.delivery.unrouted.x"}' --apply-to exchanges
+```
+
+The policy (rather than a declare-time `alternate-exchange` argument) is deliberate: the exchange already exists without that argument, and redeclaring an exchange with new arguments fails with 406 `PRECONDITION_FAILED`. Caveats:
+
+- RabbitMQ applies at most **one** policy per resource. If another policy already matches `delay.delivery.x`, merge `"alternate-exchange"` into its definition instead of adding a second policy.
+- A declare-time `alternate-exchange` argument would take precedence over the policy — the gem intentionally declares none.
+
+An alternate exchange is a routing fallback, not a retry loop — it cannot duplicate messages (unlike quorum `dead-letter-strategy=at-least-once`, which can redeliver duplicates to the target).
+
+### Redriving parked messages
+
+Parked messages retain their full bit-prefixed routing key (`b19...b0.<queue>`). To redrive:
+
+1. Fix the missing binding (start the consumer, or bind the target queue to `delay.delivery.x` with pattern `#.<queue>`).
+2. Shovel `delay.delivery.parking` → `delay.delivery.x`. The preserved routing key re-matches on its own. Do **not** shovel to the `activejob` direct exchange — the bit-prefixed key matches nothing there.
+
 ## Custom message options
 
 Advanced sneakers adapter allows to set [custom message options](http://reference.rubybunny.info/Bunny/Exchange.html#publish-instance_method) (e.g. [routing keys](https://www.rabbitmq.com/tutorials/tutorial-four-ruby.html)) on class-level.

--- a/lib/advanced_sneakers_activejob/configuration.rb
+++ b/lib/advanced_sneakers_activejob/configuration.rb
@@ -26,6 +26,13 @@ module AdvancedSneakersActiveJob
     # Number of TTL levels in the leveled delayed delivery topology.
     config_accessor(:delayed_delivery_levels) { 20 }
 
+    # When true (default), LeveledDelayedPublisher ensures the destination
+    # queue's `#.<destination>` binding on delay.delivery.x exists (just-in-time,
+    # memoized per process) before publishing a delayed message. Closes the
+    # window where a delayed job is published before the destination worker has
+    # ever booted with the new gem. Set to false to skip the JIT bind entirely.
+    config_accessor(:leveled_ensure_binding_on_publish) { true }
+
     config_accessor(:publish_connection)
 
     def republish_connection=(_)

--- a/lib/advanced_sneakers_activejob/errors.rb
+++ b/lib/advanced_sneakers_activejob/errors.rb
@@ -5,4 +5,8 @@ module AdvancedSneakersActiveJob
 
   # Raised when a delay exceeds LeveledDelayedPublisher::MAX_DELAY.
   class DelayTooLargeError < PublishError; end
+
+  # Raised by LeveledDelayedPublisher#declare_topology! when the broker is too
+  # old to support quorum-queue message TTL (RabbitMQ < 3.10).
+  class BrokerVersionError < StandardError; end
 end

--- a/lib/advanced_sneakers_activejob/leveled_delayed_publisher.rb
+++ b/lib/advanced_sneakers_activejob/leveled_delayed_publisher.rb
@@ -62,6 +62,12 @@ module AdvancedSneakersActiveJob
     UNROUTED_EXCHANGE = 'delay.delivery.unrouted.x'
     PARKING_QUEUE = 'delay.delivery.parking'
 
+    # The level queues are quorum queues declared with x-message-ttl, which
+    # RabbitMQ supports on quorum queues only from 3.10 onwards. On older
+    # brokers the declare fails with a cryptic "PRECONDITION_FAILED - invalid
+    # arg 'x-message-ttl'"; we fail fast with a clear message instead.
+    MIN_RABBITMQ_VERSION = '3.10'
+
     delegate :logger, to: :'::ActiveJob::Base'
 
     attr_reader :dlx_exchange_name, :levels, :max_delay
@@ -92,6 +98,8 @@ module AdvancedSneakersActiveJob
     def declare_topology!(channel_override = nil)
       ch = channel_override || channel
       raise 'LeveledDelayedPublisher#declare_topology! requires an open channel' if ch.nil?
+
+      ensure_broker_supports_quorum_ttl!(ch)
 
       ch.topic(DELIVERY_EXCHANGE, durable: true)
 
@@ -194,6 +202,29 @@ module AdvancedSneakersActiveJob
     end
 
     private
+
+    # Fail fast (before declaring anything) when the broker predates quorum-queue
+    # message TTL support. Best-effort: if the version can't be read, proceed and
+    # let the declare surface any real error rather than block a valid broker.
+    def ensure_broker_supports_quorum_ttl!(ch)
+      version = broker_version(ch)
+      return if version.nil?
+
+      major, minor = version.split('.', 3).first(2).map(&:to_i)
+      return if major > 3 || (major == 3 && minor >= 10)
+
+      raise BrokerVersionError,
+            "LeveledDelayedPublisher requires RabbitMQ >= #{MIN_RABBITMQ_VERSION} for quorum-queue " \
+            "message TTL (x-message-ttl on delay.level.* queues); broker reports version #{version.inspect}. " \
+            'Upgrade the broker, or use legacy delayed delivery (config.delayed_delivery = :legacy).'
+    end
+
+    def broker_version(ch)
+      version = ch.connection.server_properties['version'].to_s
+      version.empty? ? nil : version
+    rescue StandardError
+      nil
+    end
 
     def validate_levels!(value)
       unless value.is_a?(Integer) && value >= 1

--- a/lib/advanced_sneakers_activejob/leveled_delayed_publisher.rb
+++ b/lib/advanced_sneakers_activejob/leveled_delayed_publisher.rb
@@ -53,6 +53,15 @@ module AdvancedSneakersActiveJob
     # Every worker queue binds to this with pattern "#.<queue_name>".
     DELIVERY_EXCHANGE = 'delay.delivery.x'
 
+    # Safety net for messages reaching DELIVERY_EXCHANGE with no matching
+    # binding (the final hop is a broker-internal dead-letter republish, so
+    # `mandatory` cannot catch them). Attached to DELIVERY_EXCHANGE as its
+    # alternate-exchange via POLICY, never via a declare-time argument:
+    # the exchange already exists in production without that argument, and
+    # redeclaring with new args raises 406 PRECONDITION_FAILED on every boot.
+    UNROUTED_EXCHANGE = 'delay.delivery.unrouted.x'
+    PARKING_QUEUE = 'delay.delivery.parking'
+
     delegate :logger, to: :'::ActiveJob::Base'
 
     attr_reader :dlx_exchange_name, :levels, :max_delay
@@ -85,6 +94,9 @@ module AdvancedSneakersActiveJob
       raise 'LeveledDelayedPublisher#declare_topology! requires an open channel' if ch.nil?
 
       ch.topic(DELIVERY_EXCHANGE, durable: true)
+
+      unrouted_exchange = ch.fanout(UNROUTED_EXCHANGE, durable: true)
+      ch.queue(PARKING_QUEUE, durable: true, arguments: { 'x-queue-type' => 'quorum' }).bind(unrouted_exchange)
 
       (0...@levels).each do |n|
         level_exchange = ch.topic(level_exchange_name(n), durable: true)

--- a/lib/advanced_sneakers_activejob/leveled_delayed_publisher.rb
+++ b/lib/advanced_sneakers_activejob/leveled_delayed_publisher.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'set'
+
 module AdvancedSneakersActiveJob
   # Bounded power-of-two TTL delayed publisher.
   #
@@ -78,6 +80,13 @@ module AdvancedSneakersActiveJob
       @levels = levels
       @max_delay = (1 << levels) - 1
 
+      # Per-process memo of destinations already bound to DELIVERY_EXCHANGE, so
+      # steady-state delayed publishes cost zero broker round-trips. Guarded by
+      # its own mutex (independent of the parent's publish mutex) because the
+      # JIT bind happens on a dedicated channel outside the parent's lock.
+      @bound_destinations = Set.new
+      @bound_destinations_mutex = Mutex.new
+
       # Base needs an exchange; we route per-publish so the parent's
       # @exchange is effectively a placeholder. Our #exchange override
       # picks the real per-message target.
@@ -146,6 +155,13 @@ module AdvancedSneakersActiveJob
 
       if delay > 0
         destination = options[:routing_key].to_s
+
+        # JIT bind BEFORE handing off to super. The parent's #publish runs
+        # inside a non-reentrant mutex and its with_errors_handling does NOT
+        # retry Bunny::NotFound, so the bind must happen outside that locked
+        # flow — on its own dedicated channel (see #ensure_destination_binding!).
+        ensure_destination_binding!(destination)
+
         options = options.merge(routing_key: build_routing_key(delay, destination))
 
         logger.debug do
@@ -185,6 +201,11 @@ module AdvancedSneakersActiveJob
       super
       @level_exchanges = nil
       @immediate_exchange = nil
+
+      # A channel/connection rebuild means our per-process bind memo can no
+      # longer be trusted to reflect broker state we observed on the old
+      # channel; drop it so the next delayed publish re-verifies the binding.
+      @bound_destinations_mutex&.synchronize { @bound_destinations&.clear }
     end
 
     # (levels + 1)-segment routing key: b{levels-1}...b00.<destination>
@@ -259,6 +280,70 @@ module AdvancedSneakersActiveJob
         remaining >>= 1
       end
       bit
+    end
+
+    # Just-in-time bind of `delay.delivery.x -> <destination>` with routing key
+    # `#.<destination>`. NServiceBus does the equivalent on every delayed send
+    # (ConfirmsAwareChannel#SendMessage -> BindToDelayInfrastructure). This
+    # closes the window where a delayed job is published before the destination
+    # queue's worker has ever booted (and thus bound itself) with the new gem.
+    #
+    # Contract (all deliberate, see BEP-9890):
+    #   * Bind ONLY, never declare. queue_bind binds by name and needs no
+    #     knowledge of the queue's declaration arguments; declaring risks
+    #     406/PRECONDITION_FAILED against host-managed quorum/SLA/rate-limited
+    #     queue args.
+    #   * Dedicated channel, NOT the shared publish channel. A missing queue
+    #     makes the bind fail 404 (Bunny::NotFound, a channel-level exception
+    #     that closes its channel). Isolating it keeps that failure from
+    #     churning healthy publishes on the shared channel.
+    #   * Run BEFORE super, outside the parent's non-reentrant publish mutex:
+    #     Bunny::NotFound is not in bunny-publisher's RETRIABLE_ERRORS and
+    #     would otherwise escape the locked flow uncleanly.
+    #   * 404 -> warn and continue. The broker-side parking/retention nets make
+    #     the message recoverable once queue+binding appear; failing the enqueue
+    #     would be a regression vs legacy behavior.
+    #   * Memoized per destination per process, so steady state costs zero
+    #     round-trips. Accepted staleness: if ops deletes+recreates a queue, a
+    #     process that already warmed the memo will NOT re-bind until restart
+    #     (or a channel reset invalidates the memo). The parking/retention net
+    #     covers that gap.
+    def ensure_destination_binding!(destination)
+      return unless AdvancedSneakersActiveJob.config.leveled_ensure_binding_on_publish
+      return if destination.empty?
+      return if destination_bound?(destination)
+
+      ensure_connection!
+
+      bind_channel = connection.create_channel
+      begin
+        bind_channel.queue_bind(destination, DELIVERY_EXCHANGE, routing_key: "#.#{destination}")
+        mark_destination_bound(destination)
+      rescue Bunny::NotFound
+        logger.warn do
+          "LeveledDelayedPublisher: destination queue [#{destination}] does not exist yet; " \
+          "publishing delayed message anyway (parking/retention net will recover it once the " \
+          "queue and its #.#{destination} binding appear)"
+        end
+      ensure
+        bind_channel.close if bind_channel.open?
+      end
+    end
+
+    def destination_bound?(destination)
+      bound_destinations_mutex.synchronize { bound_destinations.include?(destination) }
+    end
+
+    def mark_destination_bound(destination)
+      bound_destinations_mutex.synchronize { bound_destinations.add(destination) }
+    end
+
+    def bound_destinations
+      @bound_destinations ||= Set.new
+    end
+
+    def bound_destinations_mutex
+      @bound_destinations_mutex ||= Mutex.new
     end
   end
 end

--- a/lib/advanced_sneakers_activejob/leveled_delayed_publisher.rb
+++ b/lib/advanced_sneakers_activejob/leveled_delayed_publisher.rb
@@ -328,6 +328,17 @@ module AdvancedSneakersActiveJob
       ensure
         bind_channel.close if bind_channel.open?
       end
+    # A broker/network error here (connection blip, closed channel, timeout)
+    # must not fail the enqueue: the parent publisher's retry machinery only
+    # engages inside super, and legacy behavior never raised for binding
+    # problems. Publish anyway; the failed bind is not memoized, so the next
+    # publish retries it, and the parking/retention nets cover the gap.
+    rescue StandardError => error
+      logger.warn do
+        "LeveledDelayedPublisher: could not ensure destination binding for [#{destination}] " \
+        "(#{error.class}: #{error.message}); publishing anyway (parking/retention net will " \
+        'recover the message once the binding appears)'
+      end
     end
 
     def destination_bound?(destination)

--- a/spec/advanced_sneakers_activejob/leveled_delayed_publisher_spec.rb
+++ b/spec/advanced_sneakers_activejob/leveled_delayed_publisher_spec.rb
@@ -37,6 +37,11 @@ describe AdvancedSneakersActiveJob::LeveledDelayedPublisher do
     it 'names the delivery exchange explicitly' do
       expect(described_class::DELIVERY_EXCHANGE).to eq('delay.delivery.x')
     end
+
+    it 'names the unrouted parking topology explicitly' do
+      expect(described_class::UNROUTED_EXCHANGE).to eq('delay.delivery.unrouted.x')
+      expect(described_class::PARKING_QUEUE).to eq('delay.delivery.parking')
+    end
   end
 
   describe '#level_queue_name' do
@@ -196,6 +201,7 @@ describe AdvancedSneakersActiveJob::LeveledDelayedPublisher do
     before do
       allow(publisher).to receive(:channel).and_return(channel)
       allow(channel).to receive(:topic) { |name, **| exchanges[name] }
+      allow(channel).to receive(:fanout) { |name, **| exchanges[name] }
       allow(channel).to receive(:queue) { |name, **| queues[name] }
     end
 
@@ -290,9 +296,65 @@ describe AdvancedSneakersActiveJob::LeveledDelayedPublisher do
       )
     end
 
+    it 'declares the unrouted fanout exchange and the parking quorum queue bound to it' do
+      publisher.declare_topology!
+
+      expect(channel).to have_received(:fanout).with('delay.delivery.unrouted.x', durable: true)
+      expect(channel).to have_received(:queue).with(
+        'delay.delivery.parking',
+        durable: true,
+        arguments: { 'x-queue-type' => 'quorum' }
+      )
+      expect(queues['delay.delivery.parking']).to have_received(:bind).with(exchanges['delay.delivery.unrouted.x'])
+    end
+
+    it 'keeps pre-existing declarations byte-identical (406 PRECONDITION_FAILED guard)' do
+      publisher.declare_topology!
+
+      # The alternate-exchange is attached via policy, never as a declare-time
+      # argument — delay.delivery.x already exists in production without any
+      # arguments, and redeclaring with new ones would 406 on every boot.
+      expect(channel).not_to have_received(:topic).with(anything, hash_including(:arguments))
+      expect(channel).not_to have_received(:fanout).with(anything, hash_including(:arguments))
+
+      (0...20).each do |n|
+        expect(channel).to have_received(:queue).with(
+          format('delay.level.%02d', n),
+          durable: true,
+          arguments: {
+            'x-queue-type' => 'quorum',
+            'x-message-ttl' => (1 << n) * 1000,
+            'x-dead-letter-exchange' => n.zero? ? 'delay.delivery.x' : format('delay.level.%02d.x', n - 1)
+          }
+        ).once
+      end
+    end
+
     it 'is idempotent (safe to call twice)' do
       publisher.declare_topology!
       expect { publisher.declare_topology! }.not_to raise_error
+    end
+
+    context 'against a real broker', :rabbitmq do
+      let(:connection) { Bunny.new(ENV.fetch('RABBITMQ_URL')).start }
+
+      after { connection.close }
+
+      it 'declares the parking topology and is idempotent on repeat calls' do
+        2.times { publisher.declare_topology!(connection.create_channel) }
+
+        http_api = RabbitmqHelpers.http_api
+        exchange = http_api.client.exchange_info(http_api.vhost, 'delay.delivery.unrouted.x')
+        expect(exchange.type).to eq('fanout')
+        expect(exchange.durable).to be(true)
+
+        parking = rabbitmq_queues.find { |queue| queue.name == 'delay.delivery.parking' }
+        expect(parking.durable).to be(true)
+        expect(parking.arguments.to_h).to eq('x-queue-type' => 'quorum')
+
+        bindings = rabbitmq_bindings(queue: 'delay.delivery.parking', exchange: 'delay.delivery.unrouted.x')
+        expect(bindings.size).to eq(1)
+      end
     end
   end
 end

--- a/spec/advanced_sneakers_activejob/leveled_delayed_publisher_spec.rb
+++ b/spec/advanced_sneakers_activejob/leveled_delayed_publisher_spec.rb
@@ -198,8 +198,11 @@ describe AdvancedSneakersActiveJob::LeveledDelayedPublisher do
     let(:exchanges) { Hash.new { |h, k| h[k] = instance_double('Bunny::Exchange', bind: nil) } }
     let(:queues) { Hash.new { |h, k| h[k] = instance_double('Bunny::Queue', bind: nil) } }
 
+    let(:connection) { instance_double('Bunny::Session', server_properties: { 'version' => '3.13.7' }) }
+
     before do
       allow(publisher).to receive(:channel).and_return(channel)
+      allow(channel).to receive(:connection).and_return(connection)
       allow(channel).to receive(:topic) { |name, **| exchanges[name] }
       allow(channel).to receive(:fanout) { |name, **| exchanges[name] }
       allow(channel).to receive(:queue) { |name, **| queues[name] }
@@ -333,6 +336,35 @@ describe AdvancedSneakersActiveJob::LeveledDelayedPublisher do
     it 'is idempotent (safe to call twice)' do
       publisher.declare_topology!
       expect { publisher.declare_topology! }.not_to raise_error
+    end
+
+    context 'when the broker predates quorum-queue TTL support (< 3.10)' do
+      let(:connection) { instance_double('Bunny::Session', server_properties: { 'version' => '3.8.35' }) }
+
+      it 'fails fast with a clear BrokerVersionError before declaring anything' do
+        expect { publisher.declare_topology! }
+          .to raise_error(AdvancedSneakersActiveJob::BrokerVersionError, /requires RabbitMQ >= 3\.10.*3\.8\.35/)
+
+        expect(channel).not_to have_received(:topic)
+        expect(channel).not_to have_received(:queue)
+      end
+    end
+
+    context 'when the broker is 4.x' do
+      let(:connection) { instance_double('Bunny::Session', server_properties: { 'version' => '4.0.1' }) }
+
+      it 'declares the topology' do
+        expect { publisher.declare_topology! }.not_to raise_error
+        expect(channel).to have_received(:topic).with('delay.delivery.x', durable: true).at_least(:once)
+      end
+    end
+
+    context 'when the broker version cannot be determined' do
+      let(:connection) { instance_double('Bunny::Session', server_properties: {}) }
+
+      it 'proceeds rather than blocking a possibly-valid broker' do
+        expect { publisher.declare_topology! }.not_to raise_error
+      end
     end
 
     context 'against a real broker', :rabbitmq do

--- a/spec/advanced_sneakers_activejob/leveled_delayed_publisher_spec.rb
+++ b/spec/advanced_sneakers_activejob/leveled_delayed_publisher_spec.rb
@@ -17,6 +17,9 @@ describe AdvancedSneakersActiveJob::LeveledDelayedPublisher do
     publisher.instance_variable_set(:@mutex, Mutex.new)
     publisher.instance_variable_set(:@levels, levels)
     publisher.instance_variable_set(:@max_delay, max_delay)
+    # Normally set by our initialize; set directly here since we bypass it.
+    publisher.instance_variable_set(:@bound_destinations, Set.new)
+    publisher.instance_variable_set(:@bound_destinations_mutex, Mutex.new)
     allow(publisher).to receive(:logger).and_return(Logger.new(IO::NULL))
     publisher
   end
@@ -105,6 +108,10 @@ describe AdvancedSneakersActiveJob::LeveledDelayedPublisher do
       allow(publisher).to receive(:ensure_connection!).and_return(nil)
       allow(publisher).to receive(:channel).and_return(channel)
       allow(channel).to receive(:topic).and_return(exchange)
+      # The JIT destination bind opens its own dedicated channel against a live
+      # broker; these tests focus on routing-key/exchange selection, so stub it.
+      # Its own behavior is covered by the '#ensure_destination_binding!' specs.
+      allow(publisher).to receive(:ensure_destination_binding!)
     end
 
     context 'channel lifecycle' do
@@ -189,6 +196,177 @@ describe AdvancedSneakersActiveJob::LeveledDelayedPublisher do
         publisher.publish('payload', routing_key: 'q', headers: { 'delay' => -5 })
 
         expect(channel).to have_received(:direct).with('activejob', durable: true)
+      end
+    end
+  end
+
+  describe 'just-in-time destination binding on delayed publish' do
+    # Fast tests: a fake connection whose #create_channel hands back a spy
+    # channel, so we can assert bind calls / channel isolation without a broker.
+    let(:publish_channel) { instance_double('Bunny::Channel', topic: publish_exchange, direct: publish_exchange) }
+    let(:publish_exchange) { instance_double('Bunny::Exchange', publish: nil) }
+    let(:bind_channel) { instance_double('Bunny::Channel', queue_bind: nil, close: nil, open?: true) }
+    let(:connection) { instance_double('Bunny::Session', create_channel: bind_channel) }
+
+    before do
+      # Parent publish flow: keep it off a live broker.
+      allow(publisher).to receive(:ensure_connection!).and_return(nil)
+      allow(publisher).to receive(:channel).and_return(publish_channel)
+      allow(publisher).to receive(:connection).and_return(connection)
+    end
+
+    it 'binds the destination to delay.delivery.x with a "#.<destination>" routing key on the first delayed publish' do
+      publisher.publish('payload', routing_key: 'orders', headers: { 'delay' => 47 })
+
+      expect(bind_channel).to have_received(:queue_bind).with('orders', 'delay.delivery.x', routing_key: '#.orders')
+    end
+
+    it 'performs the bind on a dedicated channel, not the shared publish channel' do
+      publisher.publish('payload', routing_key: 'orders', headers: { 'delay' => 47 })
+
+      expect(connection).to have_received(:create_channel)
+      expect(bind_channel).to have_received(:close)
+    end
+
+    it 'does not issue a second bind for the same destination (memoized per process)' do
+      publisher.publish('payload', routing_key: 'orders', headers: { 'delay' => 47 })
+      publisher.publish('payload', routing_key: 'orders', headers: { 'delay' => 3 })
+
+      expect(connection).to have_received(:create_channel).once
+      expect(bind_channel).to have_received(:queue_bind).once
+    end
+
+    it 'binds each distinct destination once' do
+      publisher.publish('payload', routing_key: 'orders', headers: { 'delay' => 5 })
+      publisher.publish('payload', routing_key: 'invoices', headers: { 'delay' => 5 })
+
+      expect(bind_channel).to have_received(:queue_bind).with('orders', 'delay.delivery.x', routing_key: '#.orders')
+      expect(bind_channel).to have_received(:queue_bind).with('invoices', 'delay.delivery.x', routing_key: '#.invoices')
+    end
+
+    it 'never binds for immediate publishes (delay <= 0)' do
+      publisher.publish('payload', routing_key: 'orders', headers: { 'delay' => 0 })
+      publisher.publish('payload', routing_key: 'orders', headers: { 'delay' => -3 })
+
+      expect(connection).not_to have_received(:create_channel)
+      expect(bind_channel).not_to have_received(:queue_bind)
+    end
+
+    it 'skips the bind entirely when config.leveled_ensure_binding_on_publish is false' do
+      AdvancedSneakersActiveJob.config.leveled_ensure_binding_on_publish = false
+
+      publisher.publish('payload', routing_key: 'orders', headers: { 'delay' => 47 })
+
+      expect(connection).not_to have_received(:create_channel)
+    ensure
+      AdvancedSneakersActiveJob.config.leveled_ensure_binding_on_publish = true
+    end
+
+    context 'when the destination queue does not exist (404)' do
+      before do
+        allow(bind_channel).to receive(:queue_bind).and_raise(Bunny::NotFound.new('NOT_FOUND', bind_channel, false))
+        # A channel-level exception closes the channel; model that.
+        allow(bind_channel).to receive(:open?).and_return(false)
+      end
+
+      it 'logs a warning and still publishes the message' do
+        expect(publisher.logger).to receive(:warn)
+
+        publisher.publish('payload', routing_key: 'ghost', headers: { 'delay' => 47 })
+
+        expect(publish_exchange).to have_received(:publish)
+      end
+
+      it 'does not memoize a failed bind (retries on the next publish)' do
+        publisher.publish('payload', routing_key: 'ghost', headers: { 'delay' => 47 })
+        publisher.publish('payload', routing_key: 'ghost', headers: { 'delay' => 47 })
+
+        expect(bind_channel).to have_received(:queue_bind).twice
+      end
+
+      it 'remains usable for other (healthy) destinations after a 404 (channel isolation)' do
+        # First destination 404s on its own dedicated channel...
+        publisher.publish('payload', routing_key: 'ghost', headers: { 'delay' => 47 })
+
+        # ...a healthy destination binds successfully on a fresh dedicated channel.
+        healthy_channel = instance_double('Bunny::Channel', queue_bind: nil, close: nil, open?: true)
+        allow(connection).to receive(:create_channel).and_return(healthy_channel)
+
+        publisher.publish('payload', routing_key: 'orders', headers: { 'delay' => 47 })
+
+        expect(healthy_channel).to have_received(:queue_bind).with('orders', 'delay.delivery.x', routing_key: '#.orders')
+      end
+    end
+
+    describe 'memo invalidation on #reset_exchange!' do
+      before { allow(publisher).to receive(:build_exchange).and_return(publish_exchange) }
+
+      it 're-binds a previously-bound destination after reset_exchange!' do
+        publisher.publish('payload', routing_key: 'orders', headers: { 'delay' => 47 })
+        expect(bind_channel).to have_received(:queue_bind).once
+
+        publisher.reset_exchange!
+
+        publisher.publish('payload', routing_key: 'orders', headers: { 'delay' => 47 })
+        expect(bind_channel).to have_received(:queue_bind).twice
+      end
+    end
+
+    context 'against a real broker', :rabbitmq do
+      let(:levels) { 4 } # keep the real topology small/fast
+      let(:real_logger) { Logger.new(IO::NULL) }
+      let(:real_connection) { Bunny.new(ENV.fetch('RABBITMQ_URL')).start }
+      let(:real_publisher) do
+        described_class.new(
+          exchange: 'activejob',
+          levels: levels,
+          connection: real_connection,
+          exchange_options: { type: 'topic', durable: true }
+        )
+      end
+
+      before do
+        # #logger delegates to ::ActiveJob::Base, which is not loaded in an
+        # isolated spec run; give the real publisher a concrete logger.
+        allow(real_publisher).to receive(:logger).and_return(real_logger)
+        setup_channel = real_connection.create_channel
+        real_publisher.declare_topology!(setup_channel)
+        # Bind-only requires the destination QUEUE to exist; declare it (with
+        # host-neutral args) so queue_bind succeeds.
+        setup_channel.queue('orders', durable: true)
+        setup_channel.close
+      end
+
+      after { real_connection.close }
+
+      it 'creates the "#.orders" binding on delay.delivery.x on first publish and reuses it on the second' do
+        real_publisher.publish('payload', routing_key: 'orders', headers: { 'delay' => 3 })
+
+        bindings = rabbitmq_bindings(queue: 'orders', exchange: 'delay.delivery.x')
+        matching = bindings.select { |b| b.routing_key == '#.orders' }
+        expect(matching.size).to eq(1)
+
+        # Second publish must not create a duplicate binding (memoized).
+        real_publisher.publish('payload', routing_key: 'orders', headers: { 'delay' => 5 })
+
+        bindings = rabbitmq_bindings(queue: 'orders', exchange: 'delay.delivery.x')
+        expect(bindings.select { |b| b.routing_key == '#.orders' }.size).to eq(1)
+      end
+
+      it 'logs a warning and still publishes when the destination queue is absent, staying usable afterwards' do
+        expect(real_logger).to receive(:warn).at_least(:once).and_call_original
+
+        expect do
+          real_publisher.publish('payload', routing_key: 'never_declared', headers: { 'delay' => 3 })
+        end.not_to raise_error
+
+        # Publisher is still usable for a healthy destination (channel isolation).
+        expect do
+          real_publisher.publish('payload', routing_key: 'orders', headers: { 'delay' => 3 })
+        end.not_to raise_error
+
+        matching = rabbitmq_bindings(queue: 'orders', exchange: 'delay.delivery.x').select { |b| b.routing_key == '#.orders' }
+        expect(matching.size).to eq(1)
       end
     end
   end

--- a/spec/advanced_sneakers_activejob/leveled_delayed_publisher_spec.rb
+++ b/spec/advanced_sneakers_activejob/leveled_delayed_publisher_spec.rb
@@ -298,6 +298,30 @@ describe AdvancedSneakersActiveJob::LeveledDelayedPublisher do
       end
     end
 
+    context 'when the broker connection blips during the bind (non-404 error)' do
+      before do
+        allow(connection).to receive(:create_channel).and_raise(Bunny::NetworkFailure.new('connection down', nil))
+      end
+
+      it 'logs a warning and still publishes the message (enqueue must never fail on a bind)' do
+        expect(publisher.logger).to receive(:warn)
+
+        publisher.publish('payload', routing_key: 'orders', headers: { 'delay' => 47 })
+
+        expect(publish_exchange).to have_received(:publish)
+      end
+
+      it 'does not memoize, so the bind retries once the connection recovers' do
+        publisher.publish('payload', routing_key: 'orders', headers: { 'delay' => 47 })
+
+        allow(connection).to receive(:create_channel).and_return(bind_channel)
+
+        publisher.publish('payload', routing_key: 'orders', headers: { 'delay' => 47 })
+
+        expect(bind_channel).to have_received(:queue_bind).with('orders', 'delay.delivery.x', routing_key: '#.orders')
+      end
+    end
+
     describe 'memo invalidation on #reset_exchange!' do
       before { allow(publisher).to receive(:build_exchange).and_return(publish_exchange) }
 


### PR DESCRIPTION
## What

Before publishing a delayed message (delay > 0), `LeveledDelayedPublisher` now idempotently ensures the binding `delay.delivery.x → <destination>` (routing key `#.<destination>`) exists, on a dedicated channel, memoized per destination. New config switch `config.leveled_ensure_binding_on_publish` (default `true`).

## Why

The consumer-side auto-bind ([BEP-9889](https://linear.app/branch/issue/BEP-9889)) leaves one window: a delayed job published **before** the destination queue's worker has ever booted with the new gem has no binding yet, so the matured message would be silently dropped ([BEP-9880](https://linear.app/branch/issue/BEP-9880)). This ports NServiceBus's producer-side just-in-time bind to close that window.

Linear: [BEP-9890](https://linear.app/branch/issue/BEP-9890)

## Hard constraints honored

- **Bind-only, never declare** the destination queue (`queue_bind` by name) — avoids `PRECONDITION_FAILED` against host-managed quorum/SLA/rate-limited queue args.
- **Dedicated channel**, never the shared publish channel: a missing queue raises `Bunny::NotFound` (a channel-level exception that closes its channel); confining it to a throwaway channel (closed in `ensure`, `open?`-guarded) means it can't churn healthy publishes.
- **Runs before `super`, outside the parent's non-reentrant publish mutex**: `Bunny::NotFound` is not in bunny-publisher's `RETRIABLE_ERRORS` and the parent's flow is mutex-locked, so the bind is done ahead of the handoff (after `ensure_connection!`).
- **404 → warn + publish anyway** (recoverable via the parking/retention nets; failing the enqueue would regress vs legacy); a failed bind is **not** memoized, so it retries next publish.
- **Memoized** per-destination in a mutex-guarded Set (independent of the publish mutex → no lock-ordering deadlock), invalidated in `reset_exchange!` (chains `super`). Accepted staleness (queue delete+recreate → warmed processes don't re-bind until restart; parking net covers it) documented in a code comment.
- `delay <= 0` never binds; **no change** to publish payload / routing-key encoding.

## Stacking

Stacked on **BEP-9891** (PR #11). Merge order: #10 (9889) → #11 (9891) → this → 9892.

## Verification

- `BUNDLE_GEMFILE=gemfiles/activejob_7.1.x.gemfile bundle exec rspec` → 127 examples, 0 failures (+12 new: first-binds/second-memoized, 404 → warn + publish + channel-isolation + no-memoize-on-failure, memo invalidated after `reset_exchange!`, no bind for delay ≤ 0, config-off skip). Core cases run against the real broker (`:rabbitmq`).
- Adversarial review found no defects and mutation-tested three specs (removing memoization / memoizing a failed bind / binding on delay ≤ 0 each fail the suite).
- rubocop is not bundled in this repo (skipped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)