### PR TITLE
Stabilize flaky 'retried job headers' integration spec

### DIFF
--- a/spec/integration/handler_spec.rb
+++ b/spec/integration/handler_spec.rb
@@ -98,8 +98,22 @@ describe 'Handler', :rabbitmq do
       describe 'retried job headers' do
         subject do
           super()
-          sleep 0.1
-          rabbitmq_messages('delayed:3').first.properties.headers
+          # The retry republish to delayed:3 is asynchronous (consume -> fail ->
+          # re-publish). Poll for the message rather than a fixed sleep so a slow
+          # CI broker does not race us to a nil read. The queue may not exist for
+          # the first few polls (404); default ackmode requeues, so repeated gets
+          # leave the message in place once it lands.
+          message = nil
+          Timeout.timeout(5) do
+            until message
+              begin
+                message = rabbitmq_messages('delayed:3').first
+              rescue Faraday::ResourceNotFound
+                nil # delayed:3 not declared yet; keep polling
+              end
+            end
+          end
+          message.properties.headers
         end
 
         it 'have error details', :aggregate_failures do


### PR DESCRIPTION
## What

`spec/integration/handler_spec.rb`'s `retried job headers … have error details` example read the retry message from `delayed:3` after a fixed `sleep 0.1`, then called `.first.properties.headers`. The retry republish (consume → fail → re-publish) is asynchronous, so on a slow CI broker `.first` was `nil` and the example failed with `undefined method 'properties' for nil:NilClass`.

## Fix

Poll for the message under a `Timeout.timeout(5)` (the pattern already used in the spec support helpers) instead of a fixed sleep, tolerating the brief window where `delay:3` is not yet declared (404). Default ackmode requeues, so repeated gets are non-destructive.

## Notes

- Pure test stabilization — no library code change. Surfaced while iterating on the delayed-delivery PR stack; split into its own PR against `main` so it can land independently of that stack.
- The sibling `:56`/`:77` examples already pass, confirming the retry path itself is fine; this was only a racy read.

🤖 Generated with [Claude Code](https://claude.com/claude-code)