### PR TITLE
update version and readme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,20 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
-## [Unreleased](https://github.com/veeqo/advanced-sneakers-activejob/compare/v0.6.0...HEAD)
+## [Unreleased](https://github.com/BranchIntl/advanced-sneakers-activejob/compare/v0.8.0...HEAD)
 
+
+## [0.8.0](https://github.com/BranchIntl/advanced-sneakers-activejob/compare/v0.7.0...v0.8.0) - 2026-07-20
+
+### Added
+- [#10](https://github.com/BranchIntl/advanced-sneakers-activejob/pull/10) Auto-bind every ActiveJob worker queue to `delay.delivery.x` (routing key `#.<queue>`) at subscribe time. Unconditional and idempotent.
+- [#11](https://github.com/BranchIntl/advanced-sneakers-activejob/pull/11) `declare_topology!` additionally declares the `delay.delivery.unrouted.x` fanout and the `delay.delivery.parking` quorum queue as a safety net for unroutable matured messages. README documents the alternate-exchange policy and the redrive runbook.
+- [#12](https://github.com/BranchIntl/advanced-sneakers-activejob/pull/12) `LeveledDelayedPublisher#publish` creates the destination binding just in time before a delayed publish when it is missing, memoized per destination per process. New config switch `leveled_ensure_binding_on_publish` (default `true`).
+
+### Fixed
+- [#11](https://github.com/BranchIntl/advanced-sneakers-activejob/pull/11) `declare_topology!` raises `AdvancedSneakersActiveJob::BrokerVersionError` on brokers older than RabbitMQ 3.10 instead of a cryptic `PRECONDITION_FAILED`.
+- [#13](https://github.com/BranchIntl/advanced-sneakers-activejob/pull/13) `Handler#error` selects its publisher through the adapter, so `:leveled` and callable `delayed_delivery` configs apply to consumer-side retries. `:legacy` behavior is unchanged.
+- [#13](https://github.com/BranchIntl/advanced-sneakers-activejob/pull/13) Queues auto-created by the mandatory republish flow are bound to both the ActiveJob exchange and `delay.delivery.x`.
 
 ## [0.6.0](https://github.com/veeqo/advanced-sneakers-activejob/compare/v0.5.0...v0.6.0) - 2022-02-15
 

--- a/README.md
+++ b/README.md
@@ -68,9 +68,11 @@ There is a setting `handle_unrouted_messages` in [configuration](#configuration)
 
 Take into accout that **this process is asynchronous**. It means that in case of network failures or process exit unrouted messages could be lost. The adapter tries to postpone application exit up to 5 seconds in case if there are unrouted messages, but it does not provide any guarantees.
 
-**Delayed messages are not handled!** If job is delayed `GuestsCleanupJob.set(wait: 1.week).perform_later(guest)` and there is no proper routing defined at the moment of job execution, it would be lost.
+Since v0.8.0 the same reachability holds for **delayed** jobs: any queue the gem's workers consume (bound at subscribe), or that this mandatory republish flow auto-creates (bound at creation), is reachable for both immediate and leveled delayed jobs, and the publisher additionally ensures the destination binding just in time before every delayed publish. Anything that still arrives at the delivery exchange with no matching binding is parked in `delay.delivery.parking` instead of being dropped — see the next section.
 
 ## Leveled delayed delivery: parking unroutable messages
+
+Host setup for leveled delivery is exactly two steps: call `AdvancedSneakersActiveJob.leveled_delayed_publisher.declare_topology!(channel)` once at boot, and attach the alternate-exchange policy shown below. Worker-queue bindings need no manual wiring — consumers bind at subscribe, the publisher ensures the binding just in time before each delayed publish, and queues auto-created by the mandatory republish flow are bound at creation.
 
 **Requirements:** the leveled path declares the `delay.level.*` queues as quorum queues with per-level message TTL (`x-message-ttl`), which RabbitMQ supports on quorum queues only from **3.10** onwards. On older brokers `LeveledDelayedPublisher#declare_topology!` fails fast with `AdvancedSneakersActiveJob::BrokerVersionError` rather than a cryptic `PRECONDITION_FAILED`; run `config.delayed_delivery = :legacy` on brokers below 3.10.
 

--- a/lib/advanced_sneakers_activejob/version.rb
+++ b/lib/advanced_sneakers_activejob/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module AdvancedSneakersActiveJob
-  VERSION = '0.7.0'
+  VERSION = '0.8.0'
 end


### PR DESCRIPTION
## Why

Gem PRs #10, #11, #12 and #13 are all merged, but there is no release for them. BranchServer will pull all of it in one bundle update. This PR names that pull 0.8.0 and fixes the docs.

## What changed

`version.rb`: 0.7.0 to 0.8.0. I went minor, not patch, because #13 changes retry behavior for other users of this gem.

`CHANGELOG.md`: new 0.8.0 section. One line per change, each linked to its PR. I didn't write a 0.7.0 section, that release never had one.

`README.md`: two fixes. I removed the old warning that delayed jobs get lost when routing is missing. That was true before #10-#13, not anymore. It now says what the gem does today: workers bind their queue at boot, publishers add the binding before sending a delayed job, and anything still unroutable goes to the parking queue. I also added one line up top: setup is two steps, `declare_topology!` at boot and the parking policy.


## Testing

Nothing here is runtime code, only docs and a version number.
